### PR TITLE
respect legacy option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
 tmp
 *.sublime-*
-
-test
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
   },
   "dependencies": {
     "chalk": "~0.3.0",
-    "fixmyjs": "~0.13.1"
+    "fixmyjs": "~0.13.1",
+    "jshint": "~2.3.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-jshint": "~0.7.2",
     "grunt-contrib-nodeunit": "~0.2.2",
-    "jshint": "~2.3.0",
     "time-grunt": "~0.2.2"
   },
   "keywords": [

--- a/tasks/fixmyjs.js
+++ b/tasks/fixmyjs.js
@@ -59,6 +59,11 @@ module.exports = function(grunt) {
 
   var fixJavaScript = function(source, options) {
     try {
+      if (options.legacy) {
+        var jshint = require('jshint').JSHINT;
+        jshint(source, options);
+        return fixmyjs(jshint.data(), source, options).run();
+      }
       return fixmyjs.fix(source, options);
     } catch (e) {
       grunt.log.error(e);


### PR DESCRIPTION
I need to use the legacy option, so that newlines are preserved. However, it doesn't seem to be respected in the current version.

See the recommendation from @goatslacker to use legacy option for preserving new lines here https://github.com/jshint/fixmyjs/issues/88
