### PR TITLE
allow for comments in .jshintrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "chalk": "~0.3.0",
     "fixmyjs": "~0.13.1",
-    "jshint": "~2.3.0"
+    "jshint": "~2.3.0",
+    "json5": "^0.2.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/tasks/fixmyjs.js
+++ b/tasks/fixmyjs.js
@@ -10,9 +10,9 @@
 
 module.exports = function(grunt) {
 
-
   var chalk = require('chalk');
   var fixmyjs = require('fixmyjs');
+  var JSON5 = require('json5');
   var _ = grunt.util._;
 
   grunt.task.registerMultiTask('fixmyjs', 'Fix your JavaScript.', function() {
@@ -22,7 +22,7 @@ module.exports = function(grunt) {
 
     // Extend default options with options from specified jshintrc file
     if (options.config) {
-      options = _.extend(options, grunt.file.readJSON(options.config));
+      options = _.extend(options, JSON5.parse(grunt.file.read(options.config)));
     }
 
     // Iterate over all specified file groups.


### PR DESCRIPTION
Currently, parsing of `.jshintrc` fails if there are comments in this file. JSHint does not force `.jshintrc` to be strict json, so we shouldn't either.

Following the conversion on gruntjs/grunt#222, the JSON5 solution seems to be easiest.
