### PR TITLE
Correct usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ A useless option.
 grunt.initConfig({
   fixmyjs: {
     options: {
-      jshintrc: '.jshintrc',
+      config: '.jshintrc',
       indentpref: 'spaces'
     },
     test: {


### PR DESCRIPTION
It could lead to confusion as it won't work with `jshintrc` but `config` =)

Thanks for the grunt plugin!
