### PR TITLE
Bump fixmyjs version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "chalk": "^0.5.1",
-    "fixmyjs": "^0.13.2",
+    "fixmyjs": "^1.0.x",
     "jshint": "^2.5.5",
     "json5": "^0.2.0"
   },


### PR DESCRIPTION
1.0.0 is a cut of the 0.13.7 release. 0.13.7 added the option `multiVar` which turns one-var style into multiVar. The rest of the changes are documented in the [CHANGELOG](https://github.com/jshint/fixmyjs/blob/master/CHANGELOG.md)