### PR TITLE
Remove grunt initConfig unnecessary semicolon

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ grunt.initConfig({
     your_target: {
       // Target-specific file lists and/or options go here.
     }
-  };
+  }
 });
 ```
 


### PR DESCRIPTION
Removed a semi-colon that was within an object literal which is a syntax error.